### PR TITLE
Update deprecated template variable access

### DIFF
--- a/templates/pagerduty.yaml.erb
+++ b/templates/pagerduty.yaml.erb
@@ -1,2 +1,2 @@
 ---
-:pagerduty_api: '<%= pagerduty_puppet_api %>'
+:pagerduty_api: '<%= @pagerduty_puppet_api %>'


### PR DESCRIPTION
Fixes

```
Variable access via 'pagerduty_puppet_api' is deprecated. Use '@pagerduty_puppet_api' instead. template[puppet-pagerduty/templates/pagerduty.yaml.erb
```
